### PR TITLE
feat: Migrate Terraform configuration from PostgreSQL to AlloyDB

### DIFF
--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -110,7 +110,7 @@ resource "google_cloud_run_v2_service" "cloud_run" {
         }
         env {
           name  = "DB_POSTGRESDB_HOST"
-          value = google_sql_database_instance.postgres_instance.private_ip_address
+          value = google_alloydb_instance.alloydb_instance.ip_address
         }
         env {
           name  = "DB_POSTGRESDB_PORT"
@@ -118,11 +118,11 @@ resource "google_cloud_run_v2_service" "cloud_run" {
         }
         env {
           name  = "DB_POSTGRESDB_DATABASE"
-          value = google_sql_database.postgres_db.name
+          value = "${var.service_name}_user"
         }
         env {
           name  = "DB_POSTGRESDB_USER"
-          value = google_sql_user.postgres_user.name
+          value = google_alloydb_cluster.alloydb_cluster.initial_user[0].user
         }
         env {
           name  = "DB_POSTGRESDB_PASSWORD"
@@ -136,7 +136,7 @@ resource "google_cloud_run_v2_service" "cloud_run" {
     }
   }
 
-  depends_on =[google_sql_database_instance.postgres_instance]
+  depends_on = [google_alloydb_instance.alloydb_instance]
 }
 
 # Permitir acesso público ao Cloud Run

--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -1,31 +1,32 @@
-resource "google_sql_database_instance" "postgres_instance" {
-  name             = "${var.service_name}-${var.environment}-postgres-instance"
-  region           = var.region
-  database_version = "POSTGRES_14"
-  depends_on = [google_service_networking_connection.private_vpc_connection]
-
-  deletion_protection = false
-  settings {
-    tier = "db-f1-micro" # Instância básica para economizar custos
-    ip_configuration {
-      private_network = google_compute_network.vpc_network.id
-      ipv4_enabled    = false # Desativa o IP público
-    }
+resource "google_alloydb_cluster" "alloydb_cluster" {
+  project       = var.project_id
+  location      = var.region
+  cluster_id    = "${var.service_name}-${var.environment}-alloydb-cluster"
+  network_config {
+    network = google_compute_network.vpc_network.id
   }
-
-  
+  initial_user {
+    user     = "${var.service_name}_user"
+    password = google_secret_manager_secret_version.db_password_version.secret_data
+  }
+  depends_on = [google_service_networking_connection.private_vpc_connection]
 }
 
+resource "google_alloydb_instance" "alloydb_instance" {
+  cluster           = google_alloydb_cluster.alloydb_cluster.name
+  instance_id       = "${var.service_name}-${var.environment}-alloydb-instance"
+  instance_type     = "PRIMARY" # Basic instance type, consider changing for production
+  machine_cpu_count = 2         # Basic machine type
+  # availability_type = "REGIONAL" # Or "ZONAL" depending on requirements. Default is ZONAL if not specified.
 
-
-
-resource "google_sql_database" "postgres_db" {
-  name     = "${var.service_name}_${var.environment}_db"
-  instance = google_sql_database_instance.postgres_instance.name
+  # Deletion protection should ideally be true for production environments
+  # deletion_protection = false
 }
 
-resource "google_sql_user" "postgres_user" {
-  name     = "${var.service_name}_user"
-  instance = google_sql_database_instance.postgres_instance.name
-  password = google_secret_manager_secret_version.db_password_version.secret_data
-}
+# Note: In AlloyDB, databases are typically created by applications upon connection if they don't exist.
+# If a specific database resource is needed at the Terraform level, it would be google_alloydb_database.
+# For now, we are relying on the initial_user and application to handle database creation.
+
+# The google_alloydb_user resource is for managing additional users if needed,
+# beyond the initial_user specified in the cluster.
+# We are using initial_user for simplicity in this migration.


### PR DESCRIPTION
I've replaced Cloud SQL for PostgreSQL resources with AlloyDB resources in terraform/database.tf. I've also updated the Cloud Run application in terraform/app.tf to use the new AlloyDB instance for its database connection.

The DB_TYPE for n8n remains 'postgresdb' due to AlloyDB's PostgreSQL compatibility. The database name for AlloyDB is set to the initial user's name.

Note: Due to execution environment limitations, I could not run `terraform plan`. Please ensure you run `terraform plan` and `terraform apply` in an environment with appropriate Google Cloud credentials to deploy these changes.