### PR TITLE
Fix: Remove invalid 'environments' top-level key from terraform.yaml

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -9,14 +9,6 @@ on:
     branches:
       - main
 
-# Define environments for approval and sequential deployment
-environments:
-  hml:
-    # Add any specific protection rules for hml if needed, e.g., reviewers
-  prd:
-    needs: hml # Specifies that prd depends on hml
-    # Add any specific protection rules for prd
-
 env:
   TF_VERSION: 1.5.7 # Versão do Terraform a ser usada
   GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }} # Credenciais do Google Cloud


### PR DESCRIPTION
The 'environments' key is not a valid top-level element in GitHub Actions workflow syntax. Deployment environments are defined in repository settings and referenced by jobs using the 'environment' key.

This commit removes the incorrect 'environments' block, resolving the workflow validation error. The jobs 'terraform_hml' and 'terraform_prd' already correctly reference their respective environments.