### PR TITLE
Fix: Pass backend configuration variables to terraform init

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -44,7 +44,7 @@ jobs:
 
       # 4. Inicializar o Terraform
       - name: Terraform Init
-        run: terraform init
+        run: terraform init -backend-config="bucket=${TF_VAR_project_id}-tfstate" -backend-config="prefix=${TF_VAR_service_name}/${TF_VAR_environment}"
 
       # 5. Validar o código Terraform
       - name: Terraform Validate
@@ -84,7 +84,7 @@ jobs:
           credentials_json: ${{ env.GOOGLE_CREDENTIALS }}
 
       - name: Terraform Init
-        run: terraform init
+        run: terraform init -backend-config="bucket=${TF_VAR_project_id}-tfstate" -backend-config="prefix=${TF_VAR_service_name}/${TF_VAR_environment}"
 
       # Terraform Validate is usually not strictly needed here if HML validated, but good for consistency
       - name: Terraform Validate

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -44,7 +44,9 @@ jobs:
 
       # 4. Inicializar o Terraform
       - name: Terraform Init
-        run: terraform init -backend-config="bucket=${TF_VAR_project_id}-tfstate" -backend-config="prefix=${TF_VAR_service_name}/${TF_VAR_environment}"
+        run: |
+          cd terraform
+          terraform init -backend-config="bucket=${TF_VAR_project_id}-tfstate" -backend-config="prefix=${TF_VAR_service_name}/${TF_VAR_environment}"
 
       # 5. Validar o código Terraform
       - name: Terraform Validate
@@ -84,7 +86,9 @@ jobs:
           credentials_json: ${{ env.GOOGLE_CREDENTIALS }}
 
       - name: Terraform Init
-        run: terraform init -backend-config="bucket=${TF_VAR_project_id}-tfstate" -backend-config="prefix=${TF_VAR_service_name}/${TF_VAR_environment}"
+        run: |
+          cd terraform
+          terraform init -backend-config="bucket=${TF_VAR_project_id}-tfstate" -backend-config="prefix=${TF_VAR_service_name}/${TF_VAR_environment}"
 
       # Terraform Validate is usually not strictly needed here if HML validated, but good for consistency
       - name: Terraform Validate


### PR DESCRIPTION
I've updated the GitHub Actions workflow to pass the necessary backend configuration variables (bucket and prefix) to the `terraform init` command. This ensures that Terraform can correctly initialize the GCS backend.

The following jobs were updated:
- terraform_hml
- terraform_prd