### PR TITLE
Fix: Correct unsupported argument for AlloyDB instance

### DIFF
--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -16,7 +16,9 @@ resource "google_alloydb_instance" "alloydb_instance" {
   cluster           = google_alloydb_cluster.alloydb_cluster.name
   instance_id       = "${var.service_name}-${var.environment}-alloydb-instance"
   instance_type     = "PRIMARY" # Basic instance type, consider changing for production
-  machine_cpu_count = 2         # Basic machine type
+  machine_config {
+    cpu_count = 2
+  }
   # availability_type = "REGIONAL" # Or "ZONAL" depending on requirements. Default is ZONAL if not specified.
 
   # Deletion protection should ideally be true for production environments


### PR DESCRIPTION
The `machine_cpu_count` argument is not supported by the `google_alloydb_instance` resource. This commit replaces it with a `machine_config` block and a `cpu_count` attribute to correctly specify the number of CPUs for the instance.

This change addresses the Terraform error:
  Error: Unsupported argument
  on database.tf line 19, in resource "google_alloydb_instance" "alloydb_instance":
  19:   machine_cpu_count = 2